### PR TITLE
Preapring APIkey for Show Once feat

### DIFF
--- a/api/v1alpha1/apikey_types.go
+++ b/api/v1alpha1/apikey_types.go
@@ -83,6 +83,10 @@ type APIKeyStatus struct {
 	// +optional
 	SecretRef *SecretReference `json:"secretRef,omitempty"`
 
+	// CanReadSecret expresses the permission to read the APIKey's secret
+	// +kubebuilder:default=true
+	CanReadSecret bool `json:"canReadSecret,omitempty"`
+
 	// Conditions represent the latest available observations of the APIKey's state
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
+++ b/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
@@ -100,6 +100,11 @@ spec:
               apiHostname:
                 description: APIHostname is the hostname from the HTTPRoute
                 type: string
+              canReadSecret:
+                default: true
+                description: CanReadSecret expresses the permission to read the APIKey's
+                  secret
+                type: boolean
               conditions:
                 description: Conditions represent the latest available observations
                   of the APIKey's state


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-backstage-plugin/issues/103

* [x] Adding `CanReadSecret` bool in order for "Show Once" feat
~~* [x] REST API Endpoint~~

**Notes** 
After discussing the approach with @eguzki, we abandoned the idea of creating a REST API within the controller, the commits were reverted and decided to move the logic of accessing the Secret to the Backstage plugin backed. The Controller only will reconcile the Status, while the Backstage backend will request the secret, based on 3 conditions: 1. `CanReadSecret == true`, 2. `APIKey.Phase == "Approved"` and 3 `APIKey.SecretReference exists`.