### PR TITLE
Gh 96 adding status condition for openapispec

### DIFF
--- a/api/v1alpha1/apiproduct_types.go
+++ b/api/v1alpha1/apiproduct_types.go
@@ -31,6 +31,7 @@ const (
 	StatusConditionPlanPolicyDiscovered string = "PlanPolicyDiscovered"
 	StatusConditionAuthPolicyDiscovered string = "AuthPolicyDiscovered"
 	StatusConditionOIDCDiscovered       string = "OIDCDiscovered"
+	StatusConditionOpenAPISpecReady     string = "OpenAPISpecReady"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -125,6 +126,10 @@ type OpenAPIStatus struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=date-time
 	LastSyncTime metav1.Time `json:"lastSyncTime" protobuf:"bytes,4,opt,name=lastSyncTime"`
+
+	// maxSizeUsed is the max size limit that was in effect when this spec was fetched.
+	// +optional
+	MaxSizeUsed int `json:"maxSizeUsed,omitempty"`
 }
 
 // OIDCDiscoveryStatus contains OIDC discovery information fetched from the issuer

--- a/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
+++ b/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
@@ -2663,6 +2663,10 @@ spec:
                       updated.
                     format: date-time
                     type: string
+                  maxSizeUsed:
+                    description: maxSizeUsed is the max size limit that was in effect
+                      when this spec was fetched.
+                    type: integer
                   raw:
                     description: raw content
                     type: string

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,9 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+        - name: OPENAPI_SPEC_MAX_SIZE
+          value: "512000"  
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/controller/apiproduct_controller_authpolicy_discover_test.go
+++ b/internal/controller/apiproduct_controller_authpolicy_discover_test.go
@@ -152,8 +152,9 @@ var _ = Describe("APIProduct Controller: AuthPolicy Discovery", func() {
 		It("should discover auth scheme from route-targeted authpolicy", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -297,8 +298,9 @@ var _ = Describe("APIProduct Controller: AuthPolicy Discovery", func() {
 		It("should discover auth scheme from gateway-targeted authpolicy", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -396,8 +398,9 @@ var _ = Describe("APIProduct Controller: AuthPolicy Discovery", func() {
 		It("should indicate httproute is ready but no authpolicy found", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -523,8 +526,9 @@ var _ = Describe("APIProduct Controller: AuthPolicy Discovery", func() {
 		It("should not discover auth scheme", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})

--- a/internal/controller/apiproduct_controller_oidc_discover_test.go
+++ b/internal/controller/apiproduct_controller_oidc_discover_test.go
@@ -162,9 +162,10 @@ var _ = Describe("APIProduct Controller: OIDC Discovery", func() {
 
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -284,9 +285,10 @@ var _ = Describe("APIProduct Controller: OIDC Discovery", func() {
 			By("Reconciling the created resource")
 			mockClient := &mockHTTPClient{}
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -400,9 +402,10 @@ var _ = Describe("APIProduct Controller: OIDC Discovery", func() {
 
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -523,9 +526,10 @@ var _ = Describe("APIProduct Controller: OIDC Discovery", func() {
 			}
 
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})

--- a/internal/controller/apiproduct_controller_test.go
+++ b/internal/controller/apiproduct_controller_test.go
@@ -160,8 +160,9 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should discover plans from route-targeted planpolicy", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -289,8 +290,9 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should discover plans from gateway-targeted planpolicy", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -373,8 +375,9 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should set ready condition to false when httproute not found", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -454,8 +457,9 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should indicate httproute is ready but no planpolicy found", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -569,8 +573,9 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should set ready condition to false when httproute is not accepted", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &APIProductReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -670,9 +675,10 @@ var _ = Describe("APIProduct Controller", func() {
 			}
 
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -699,9 +705,10 @@ var _ = Describe("APIProduct Controller", func() {
 			}
 
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: mockClient,
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         mockClient,
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})
@@ -785,9 +792,10 @@ var _ = Describe("APIProduct Controller", func() {
 		It("should not populate OpenAPI status", func() {
 			By("Reconciling the resource")
 			controllerReconciler := &APIProductReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				HTTPClient: &mockHTTPClient{},
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				HTTPClient:         &mockHTTPClient{},
+				OpenAPISpecMaxSize: 500 * 1024,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{})


### PR DESCRIPTION
Closes one part of https://github.com/Kuadrant/kuadrant-backstage-plugin/issues/96
## Changes:
* Added StatusConditionOpenAPISpecReady to track OpenAPI spec fetch status
* Added custom error type OpenAPISpecErr for structured error handling
* Enhanced error handling for HTTP fetch failures (non-200 status codes)
* Added 500KB size limit validation for OpenAPI specs
* Fixed caching logic to prevent unnecessary re-fetching

#Verification
- Create a Kind cluster and install dependencies:
 ```bash
 make kind-create-cluster
 make install
 make gateway-api-install
 make kuadrant-core-install
```

- Deploy the controller locally:

```bash
make run
```

 - Create Gateway and httproute
 ```bash
 kubectl create ns gateway-system

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: my-gateway
  namespace: gateway-system
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    protocol: HTTP
    port: 80
    hostname: "example.com"
    allowedRoutes:
      namespaces:
        from: All
EOF

kubectl create ns toystore

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: my-route
  namespace: toystore
spec:
  hostnames:
    - example.com
  parentRefs:
    - name: my-gateway
      namespace: gateway-system
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/"
      backendRefs:
        - name: toystore
          port: 80
EOF
```

- Create APiProduct (To not reinvent the wheel im using King Eguzki gist for the openapispec url)
```bash
kubectl apply -f - <<EOF
apiVersion: devportal.kuadrant.io/v1alpha1
kind: APIProduct
metadata:
  name: toystore-api
  namespace: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: my-route
  displayName: Toystore API
  description: Manage toy inventory
  approvalMode: manual
  publishStatus: Published
  documentation:
    openAPISpecURL: https://gist.githubusercontent.com/eguzki/1ba21b75a2df0b3a9c78f83181a5a950/raw/7460b6b7bb8e1761327adbfb979d8f4f8d2e7008/petstore-openapi.yaml
EOF
```

- Everything should be hunky dory, so you should see
``` bash
 - lastTransitionTime: "2026-01-16T11:55:33Z"
      message: OpenAPI spec was successfully fetched
      reason: SpecFetched
      status: "True"
      type: OpenAPISpecReady
    observedGeneration: 3
    openapi:
      lastSyncTime: "2026-01-16T11:55:33Z"
      raw: |-
        {
          "openapi": "3.1.0",
          "info": {
            "version": "1.0.0",
            "title": "Swagger Petstore",
            "license": {
              "name": "MIT",
              "url": "https://opensource.org/licenses/MIT"
            }
          },
```



- Update file size limit to 1024 via env var `OPENAPI_SPEC_MAX_SIZE=1024 make run
`

- You should see in the conditions
```bash
- lastTransitionTime: "2026-01-16T11:42:16Z"
      message: OpenAPI spec exceeds size limit (1024 bytes)
      reason: SpecSizeTooLarge
      status: "False"
      type: OpenAPISpecReady
    observedGeneration: 3
    openapi:
      lastSyncTime: "2026-01-16T11:54:56Z"
      raw: ""
```

- Edit the url to be wrong to create a 404 e.g change eguzki to eguz you should see
```bash
kubectl edit apiproduct -n toystore
```
```bash
 - lastTransitionTime: "2026-01-16T11:55:53Z"
      message: 'failed to fetch OpenAPI spec from https://gist.githubusercontent.com/egki/1ba21b75a2df0b3a9c78f83181a5a950/raw/7460b6b7bb8e1761327adbfb979d8f4f8d2e7008/petstore-openapi.yaml:
        unexpected status code 404'
      reason: FetchFailed
      status: "False"
      type: OpenAPISpecReady
    observedGeneration: 4
    openapi:
      lastSyncTime: "2026-01-16T11:55:53Z"
      raw: ""

```


