### PR TITLE
add v to the docker tag on semver

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -38,7 +38,7 @@ jobs:
             # git sha
             type=raw,value=${{ github.sha }},enable={{is_default_branch}}
             # will be used on a push tag event and requires a valid semver Git tag
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Read release string version


### PR DESCRIPTION
On push tag event, the docker tag missed the prefix  `v`. This pr modifies the config so on git tag `v1.2.3` it will produce docker image `quay.io/kuadrant/developer-portal-controller:v1.2.3`