### PR TITLE
fix: do not set latest tag for tag events

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_REGISTRY_REPO }}
+          flavor: |
+            latest=false
           tags: |
             # branch event
             type=ref,enable=true,priority=600,prefix=,suffix=,event=branch


### PR DESCRIPTION
# Description
Part of: https://github.com/Kuadrant/kuadrant-operator/issues/1752

Latest tag is generated when a github tag is pushed (for example - https://github.com/Kuadrant/developer-portal-controller/actions/runs/21716165927 - check tags from metadata action)
<img width="858" height="242" alt="image" src="https://github.com/user-attachments/assets/8a73cb6d-0215-4c73-8761-b8ea00f83800" />

This causes the `latest` tag in quay.io to be linked with the `vX.Y.Z` tag

The cause is due to when the `type=semver` is used in the github action, the default behaviour is that a `latest` tag is also generated along with the pushed github semver tag
- https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input

Tested in my own fork:
- [Main run](https://github.com/KevFan/developer-portal-controller/actions/runs/22850351606/job/66277080375) :
<img width="868" height="266" alt="image" src="https://github.com/user-attachments/assets/17e02137-425c-43a5-abcd-8a94f7674d61" />

- [Tag run](https://github.com/KevFan/developer-portal-controller/actions/runs/22850376847/job/66277167087) :
<img width="875" height="380" alt="image" src="https://github.com/user-attachments/assets/2ca0c086-5f67-468a-bcf6-6d05812a18a1" />

