### PR TITLE
Enable s390x support

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Summary
Update the CI image build pipeline to publish the controller image for linux/s390x in addition to linux/amd64 and linux/arm64.

Changes
Updated .github/workflows/build-image.yaml to extend the platforms list from linux/amd64,linux/arm64 to linux/amd64,linux/arm64,linux/s390x.
