### PR TITLE
apikey automatic approval controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,16 +93,12 @@ test: manifests generate fmt vet setup-envtest gateway-api-crds kuadrant-crds ##
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# CertManager is installed by default; skip with: CERT_MANAGER_INSTALL_SKIP=true
+CERT_MANAGER_INSTALL_SKIP ?= true
 KIND_CLUSTER ?= developer-portal-controller-test-e2e
 
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
-	@command -v $(KIND) >/dev/null 2>&1 || { \
-		echo "Kind is not installed. Please install Kind manually."; \
-		exit 1; \
-	}
+setup-test-e2e: kind ## Set up a Kind cluster for e2e tests if it does not exist
 	@case "$$($(KIND) get clusters)" in \
 		*"$(KIND_CLUSTER)"*) \
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
@@ -110,14 +106,26 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@echo ""
+	@echo "installing developer portal controller APIs..."
+	@$(MAKE) install
+	@echo ""
+	@echo "installing Gateway API APIs..."
+	@$(MAKE) gateway-api-install
+	@echo ""
+	@echo "installing kuadrant core APIs..."
+	@$(MAKE) kuadrant-core-install
+	@echo ""
+	@echo "cluster ready! Kuadrant and Gateway API APIs installed."
+	@echo ""
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	PATH="$(LOCALBIN):$$PATH" KIND_CLUSTER=$(KIND_CLUSTER) CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) go test ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e
-cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
+cleanup-test-e2e: kind ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,13 @@ setup-test-e2e: kind ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	PATH="$(LOCALBIN):$$PATH" KIND_CLUSTER=$(KIND_CLUSTER) CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) go test ./test/e2e/ -v -ginkgo.v
-	$(MAKE) cleanup-test-e2e
+	@set +e; \
+	PATH="$(LOCALBIN):$$PATH" \
+	KIND_CLUSTER=$(KIND_CLUSTER) \
+	CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) \
+	go test ./test/e2e/ -v -ginkgo.v; status=$$?; \
+	$(MAKE) cleanup-test-e2e; \
+	exit $$status
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: kind ## Tear down the Kind cluster used for e2e tests

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -305,6 +305,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "APIKeyApprovalStatus")
 		os.Exit(1)
 	}
+	if err := (&controller.APIKeyAutoApprovalReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "APIKeyAutoApproval")
+		os.Exit(1)
+	}
 	if err := (&controller.APIKeySecretReconciler{
 		BaseReconciler: reconcilers.BaseReconciler{
 			Client: mgr.GetClient(),

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   resources:
   - apikeyapprovals
   verbs:
+  - create
   - get
   - list
   - patch

--- a/internal/controller/apikey_auto_approval_controller.go
+++ b/internal/controller/apikey_auto_approval_controller.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	devportalv1alpha1 "github.com/kuadrant/developer-portal-controller/api/v1alpha1"
+)
+
+// APIKeyAutoApprovalReconciler automatically creates APIKeyApproval resources
+// for APIKeyRequests targeting APIProducts with automatic approval mode
+type APIKeyAutoApprovalReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyrequests,verbs=get;list;watch
+// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyapprovals,verbs=get;list;create
+// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apiproducts,verbs=get;list
+
+func (r *APIKeyAutoApprovalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logf.FromContext(ctx, "apikeyrequest", req.NamespacedName)
+	logger.V(1).Info("reconciling apikey auto approval")
+	defer logger.V(1).Info("reconciling apikey auto approval: done")
+
+	// Get APIKeyRequest object
+	apiKeyRequest := &devportalv1alpha1.APIKeyRequest{}
+	if err := r.Get(ctx, req.NamespacedName, apiKeyRequest); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("no object found")
+			return ctrl.Result{}, nil
+		}
+
+		logger.Error(err, "Failed to get apikeyrequest object.")
+		return ctrl.Result{}, err
+	}
+
+	if apiKeyRequest.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// 1. Check if APIKeyRequest has Pending condition with status=True
+	// If status hasn't been set yet, we proceed anyway (defensive programming)
+	pendingCondition := meta.FindStatusCondition(apiKeyRequest.Status.Conditions, devportalv1alpha1.APIKeyConditionPending)
+
+	// Skip if not pending (either approved, denied, or other state)
+	if pendingCondition == nil || pendingCondition.Status != metav1.ConditionTrue {
+		logger.V(1).Info("APIKeyRequest is not in pending state, skipping auto-approval")
+		return ctrl.Result{}, nil
+	}
+
+	// 2. Fetch the referenced APIProduct
+	product := &devportalv1alpha1.APIProduct{}
+	productKey := client.ObjectKey{
+		Namespace: apiKeyRequest.Namespace,
+		Name:      apiKeyRequest.Spec.APIProductRef.Name,
+	}
+	if err := r.Get(ctx, productKey, product); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("referenced APIProduct not found")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// 3. Check if APIProduct is being deleted
+	if product.GetDeletionTimestamp() != nil {
+		logger.V(1).Info("APIProduct is being deleted, skipping auto-approval")
+		return ctrl.Result{}, nil
+	}
+
+	// 4. Check if approval mode is automatic
+	if product.Spec.ApprovalMode != "automatic" {
+		logger.V(1).Info("APIProduct approval mode is not automatic", "mode", product.Spec.ApprovalMode)
+		return ctrl.Result{}, nil
+	}
+
+	// 6. Create auto-approval
+	approval := &devportalv1alpha1.APIKeyApproval{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apiKeyRequest.Name + "-auto",
+			Namespace: apiKeyRequest.Namespace,
+		},
+		Spec: devportalv1alpha1.APIKeyApprovalSpec{
+			APIKeyRequestRef: devportalv1alpha1.APIKeyRequestReference{
+				Name: apiKeyRequest.Name,
+			},
+			Approved:   true,
+			ReviewedBy: "system",
+			ReviewedAt: metav1.Now(),
+			Reason:     "AutoApproved",
+			Message:    "Automatically approved based on APIProduct approval mode",
+		},
+	}
+
+	logger.Info("creating automatic approval")
+	err := r.Create(ctx, approval)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Approval already created (race condition or duplicate), skip
+			logger.V(1).Info("auto-approval already exists", "apikeyrequest", client.ObjectKeyFromObject(apiKeyRequest))
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *APIKeyAutoApprovalReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&devportalv1alpha1.APIKeyRequest{}).
+		Named("apikeyrequest-autoapproval").
+		Complete(r)
+}

--- a/internal/controller/apikey_auto_approval_controller.go
+++ b/internal/controller/apikey_auto_approval_controller.go
@@ -98,6 +98,21 @@ func (r *APIKeyAutoApprovalReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	// 5. Check if any APIKeyApproval already exists for this request
+	// Address race conditions when apikey is still pending but an apikeyapproval resource already exists.
+	approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+	if err := r.List(ctx, approvalList, client.InNamespace(apiKeyRequest.Namespace)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, approval := range approvalList.Items {
+		if approval.Spec.APIKeyRequestRef.Name == apiKeyRequest.Name {
+			logger.V(1).Info("APIKeyApproval already exists for this request, skipping auto-approval",
+				"approval", approval.Name)
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// 6. Create auto-approval
 	approval := &devportalv1alpha1.APIKeyApproval{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/apikey_auto_approval_controller_test.go
+++ b/internal/controller/apikey_auto_approval_controller_test.go
@@ -1,0 +1,459 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	devportalv1alpha1 "github.com/kuadrant/developer-portal-controller/api/v1alpha1"
+)
+
+var _ = Describe("APIKeyAutoApproval Controller", func() {
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+	)
+	var (
+		apiProductNamespace string
+		consumerNamespace   string
+		apiKeyName          = "test-apikey"
+		apiProductName      = "test-api-product"
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		createNamespaceWithContext(ctx, &apiProductNamespace)
+		createNamespaceWithContext(ctx, &consumerNamespace)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		deleteAPIKeysWithContext(ctx, consumerNamespace)
+		deleteAPIKeyRequestsWithContext(ctx, apiProductNamespace)
+		deleteAPIKeyApprovalsWithContext(ctx, apiProductNamespace)
+		deleteNamespaceWithContext(ctx, apiProductNamespace)
+		deleteNamespaceWithContext(ctx, consumerNamespace)
+	}, nodeTimeOut)
+
+	Context("When reconciling APIKeyRequest with automatic approval mode", func() {
+		var (
+			apiProduct    *devportalv1alpha1.APIProduct
+			apiKeyRequest *devportalv1alpha1.APIKeyRequest
+		)
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			By("Creating an APIProduct with automatic approval mode")
+			apiProduct = &devportalv1alpha1.APIProduct{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIProductSpec{
+					DisplayName:  "Test API",
+					ApprovalMode: "automatic",
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gwapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  "test-route",
+					},
+					PublishStatus: "Draft",
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiProduct)).To(Succeed())
+
+			By("Creating an APIKeyRequest")
+			apiKeyRequest = &devportalv1alpha1.APIKeyRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductNamespace + "-" + apiKeyName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyRequestSpec{
+					APIProductRef: devportalv1alpha1.LocalAPIProductReference{
+						Name: apiProductName,
+					},
+					PlanTier: "premium",
+					UseCase:  "Testing automatic approval",
+					RequestedBy: devportalv1alpha1.RequestedBy{
+						UserID: "test-user",
+						Email:  "test@example.com",
+					},
+					APIKeyRef: devportalv1alpha1.APIKeyReference{
+						Name:      apiKeyName,
+						Namespace: consumerNamespace,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiKeyRequest)).To(Succeed())
+
+			By("Setting the APIKeyRequest status to Pending")
+			updatedRequest := &devportalv1alpha1.APIKeyRequest{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      apiKeyRequest.Name,
+				Namespace: apiProductNamespace,
+			}, updatedRequest)).To(Succeed())
+
+			meta.SetStatusCondition(&updatedRequest.Status.Conditions, metav1.Condition{
+				Type:               devportalv1alpha1.APIKeyConditionPending,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Pending",
+				Message:            "Awaiting approval",
+				ObservedGeneration: updatedRequest.Generation,
+			})
+			Expect(k8sClient.Status().Update(ctx, updatedRequest)).To(Succeed())
+		})
+
+		It("should create automatic approval for pending request", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Waiting for APIKeyRequest status to be set")
+			requestKey := types.NamespacedName{
+				Name:      apiKeyRequest.Name,
+				Namespace: apiProductNamespace,
+			}
+			Eventually(func() bool {
+				fetchedRequest := &devportalv1alpha1.APIKeyRequest{}
+				if err := k8sClient.Get(ctx, requestKey, fetchedRequest); err != nil {
+					return false
+				}
+				pendingCondition := meta.FindStatusCondition(fetchedRequest.Status.Conditions, devportalv1alpha1.APIKeyConditionPending)
+				return pendingCondition != nil && pendingCondition.Status == metav1.ConditionTrue
+			}, time.Second*5, time.Millisecond*250).Should(BeTrue(), "APIKeyRequest should have Pending condition set")
+
+			By("Running reconciliation for the specific APIKeyRequest")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: requestKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying APIKeyApproval was created")
+			approval := &devportalv1alpha1.APIKeyApproval{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      apiKeyRequest.Name + "-auto",
+					Namespace: apiProductNamespace,
+				}, approval)
+				return err == nil
+			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+
+			By("Verifying approval has correct fields")
+			Expect(approval.Spec.APIKeyRequestRef.Name).To(Equal(apiKeyRequest.Name))
+			Expect(approval.Spec.Approved).To(BeTrue())
+			Expect(approval.Spec.ReviewedBy).To(Equal("system"))
+			Expect(approval.Spec.Reason).To(Equal("AutoApproved"))
+			Expect(approval.Spec.Message).To(Equal("Automatically approved based on APIProduct approval mode"))
+		})
+
+		It("should be idempotent and not create duplicate approvals", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requestKey := types.NamespacedName{
+				Name:      apiKeyRequest.Name,
+				Namespace: apiProductNamespace,
+			}
+
+			By("Waiting for APIKeyRequest status to be set")
+			Eventually(func() bool {
+				fetchedRequest := &devportalv1alpha1.APIKeyRequest{}
+				if err := k8sClient.Get(ctx, requestKey, fetchedRequest); err != nil {
+					return false
+				}
+				pendingCondition := meta.FindStatusCondition(fetchedRequest.Status.Conditions, devportalv1alpha1.APIKeyConditionPending)
+				return pendingCondition != nil && pendingCondition.Status == metav1.ConditionTrue
+			}, time.Second*5, time.Millisecond*250).Should(BeTrue(), "APIKeyRequest should have Pending condition set")
+
+			By("Running reconciliation first time")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: requestKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying approval was created")
+			approval := &devportalv1alpha1.APIKeyApproval{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      apiKeyRequest.Name + "-auto",
+					Namespace: apiProductNamespace,
+				}, approval)
+				return err == nil
+			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+
+			By("Running reconciliation second time")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: requestKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying only one approval exists")
+			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
+			Expect(approvalList.Items).To(HaveLen(1), "Should not create duplicate approvals")
+		})
+	})
+
+	Context("When reconciling APIKeyRequest with manual approval mode", func() {
+		var (
+			apiProduct    *devportalv1alpha1.APIProduct
+			apiKeyRequest *devportalv1alpha1.APIKeyRequest
+		)
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			By("Creating an APIProduct with manual approval mode")
+			apiProduct = &devportalv1alpha1.APIProduct{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIProductSpec{
+					DisplayName:  "Test API",
+					ApprovalMode: "manual",
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gwapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  "test-route",
+					},
+					PublishStatus: "Draft",
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiProduct)).To(Succeed())
+
+			By("Creating an APIKeyRequest in pending state")
+			apiKeyRequest = &devportalv1alpha1.APIKeyRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductNamespace + "-" + apiKeyName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyRequestSpec{
+					APIProductRef: devportalv1alpha1.LocalAPIProductReference{
+						Name: apiProductName,
+					},
+					PlanTier: "premium",
+					UseCase:  "Testing manual approval",
+					RequestedBy: devportalv1alpha1.RequestedBy{
+						UserID: "test-user",
+						Email:  "test@example.com",
+					},
+					APIKeyRef: devportalv1alpha1.APIKeyReference{
+						Name:      apiKeyName,
+						Namespace: consumerNamespace,
+					},
+				},
+				Status: devportalv1alpha1.APIKeyRequestStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               devportalv1alpha1.APIKeyConditionPending,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Pending",
+							Message:            "Awaiting approval",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiKeyRequest)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, apiKeyRequest)).To(Succeed())
+		})
+
+		It("should not create automatic approval", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Running reconciliation for the specific APIKeyRequest")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      apiKeyRequest.Name,
+					Namespace: apiProductNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no approval was created")
+			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
+			Expect(approvalList.Items).To(BeEmpty(), "Should not create approval for manual mode")
+		})
+	})
+
+	Context("When reconciling APIKeyRequest with missing APIProduct", func() {
+		var (
+			apiKeyRequest *devportalv1alpha1.APIKeyRequest
+		)
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			By("Creating an APIKeyRequest referencing non-existent APIProduct")
+			apiKeyRequest = &devportalv1alpha1.APIKeyRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductNamespace + "-" + apiKeyName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyRequestSpec{
+					APIProductRef: devportalv1alpha1.LocalAPIProductReference{
+						Name: "non-existent-product",
+					},
+					PlanTier: "premium",
+					UseCase:  "Testing missing product",
+					RequestedBy: devportalv1alpha1.RequestedBy{
+						UserID: "test-user",
+						Email:  "test@example.com",
+					},
+					APIKeyRef: devportalv1alpha1.APIKeyReference{
+						Name:      apiKeyName,
+						Namespace: consumerNamespace,
+					},
+				},
+				Status: devportalv1alpha1.APIKeyRequestStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               devportalv1alpha1.APIKeyConditionPending,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Pending",
+							Message:            "Awaiting approval",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiKeyRequest)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, apiKeyRequest)).To(Succeed())
+		})
+
+		It("should handle missing APIProduct gracefully", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Running reconciliation for the specific APIKeyRequest")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      apiKeyRequest.Name,
+					Namespace: apiProductNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no approval was created")
+			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
+			Expect(approvalList.Items).To(BeEmpty(), "Should not create approval when APIProduct is missing")
+		})
+	})
+
+	Context("When reconciling with APIProduct being deleted", func() {
+		var (
+			apiProduct    *devportalv1alpha1.APIProduct
+			apiKeyRequest *devportalv1alpha1.APIKeyRequest
+		)
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			By("Creating an APIProduct with automatic approval mode")
+			apiProduct = &devportalv1alpha1.APIProduct{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIProductSpec{
+					DisplayName:  "Test API",
+					ApprovalMode: "automatic",
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gwapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  "test-route",
+					},
+					PublishStatus: "Draft",
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiProduct)).To(Succeed())
+
+			By("Creating an APIKeyRequest in pending state")
+			apiKeyRequest = &devportalv1alpha1.APIKeyRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductNamespace + "-" + apiKeyName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyRequestSpec{
+					APIProductRef: devportalv1alpha1.LocalAPIProductReference{
+						Name: apiProductName,
+					},
+					PlanTier: "premium",
+					UseCase:  "Testing deleted product",
+					RequestedBy: devportalv1alpha1.RequestedBy{
+						UserID: "test-user",
+						Email:  "test@example.com",
+					},
+					APIKeyRef: devportalv1alpha1.APIKeyReference{
+						Name:      apiKeyName,
+						Namespace: consumerNamespace,
+					},
+				},
+				Status: devportalv1alpha1.APIKeyRequestStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               devportalv1alpha1.APIKeyConditionPending,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Pending",
+							Message:            "Awaiting approval",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiKeyRequest)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, apiKeyRequest)).To(Succeed())
+
+			By("Marking APIProduct for deletion")
+			Expect(k8sClient.Delete(ctx, apiProduct)).To(Succeed())
+		})
+
+		It("should not create approval for product being deleted", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Running reconciliation for the specific APIKeyRequest")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      apiKeyRequest.Name,
+					Namespace: apiProductNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no approval was created")
+			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
+			Expect(approvalList.Items).To(BeEmpty(), "Should not create approval for product being deleted")
+		})
+	})
+})

--- a/internal/controller/apikey_auto_approval_controller_test.go
+++ b/internal/controller/apikey_auto_approval_controller_test.go
@@ -209,7 +209,7 @@ var _ = Describe("APIKeyAutoApproval Controller", func() {
 
 			By("Verifying only one approval exists")
 			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
-			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
+			Expect(k8sClient.List(ctx, approvalList, client.InNamespace(apiProductNamespace))).To(Succeed())
 			Expect(approvalList.Items).To(HaveLen(1), "Should not create duplicate approvals")
 		})
 	})

--- a/internal/controller/apikey_auto_approval_controller_test.go
+++ b/internal/controller/apikey_auto_approval_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -454,6 +455,129 @@ var _ = Describe("APIKeyAutoApproval Controller", func() {
 			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
 			Expect(k8sClient.List(ctx, approvalList)).To(Succeed())
 			Expect(approvalList.Items).To(BeEmpty(), "Should not create approval for product being deleted")
+		})
+	})
+
+	Context("When APIKeyApproval already exists for the request", func() {
+		var (
+			apiProduct     *devportalv1alpha1.APIProduct
+			apiKeyRequest  *devportalv1alpha1.APIKeyRequest
+			manualApproval *devportalv1alpha1.APIKeyApproval
+		)
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			By("Creating an APIProduct with automatic approval mode")
+			apiProduct = &devportalv1alpha1.APIProduct{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIProductSpec{
+					DisplayName:  "Test API",
+					ApprovalMode: "automatic",
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gwapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  "test-route",
+					},
+					PublishStatus: "Draft",
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiProduct)).To(Succeed())
+
+			By("Creating an APIKeyRequest in pending state")
+			apiKeyRequest = &devportalv1alpha1.APIKeyRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiProductNamespace + "-" + apiKeyName,
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyRequestSpec{
+					APIProductRef: devportalv1alpha1.LocalAPIProductReference{
+						Name: apiProductName,
+					},
+					PlanTier: "premium",
+					UseCase:  "Testing existing approval",
+					RequestedBy: devportalv1alpha1.RequestedBy{
+						UserID: "test-user",
+						Email:  "test@example.com",
+					},
+					APIKeyRef: devportalv1alpha1.APIKeyReference{
+						Name:      apiKeyName,
+						Namespace: consumerNamespace,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, apiKeyRequest)).To(Succeed())
+
+			By("Setting the APIKeyRequest status to Pending")
+			updatedRequest := &devportalv1alpha1.APIKeyRequest{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      apiKeyRequest.Name,
+				Namespace: apiProductNamespace,
+			}, updatedRequest)).To(Succeed())
+
+			meta.SetStatusCondition(&updatedRequest.Status.Conditions, metav1.Condition{
+				Type:               devportalv1alpha1.APIKeyConditionPending,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Pending",
+				Message:            "Awaiting approval",
+				ObservedGeneration: updatedRequest.Generation,
+			})
+			Expect(k8sClient.Status().Update(ctx, updatedRequest)).To(Succeed())
+
+			By("Creating a manual APIKeyApproval for this request")
+			manualApproval = &devportalv1alpha1.APIKeyApproval{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiKeyRequest.Name + "-manual",
+					Namespace: apiProductNamespace,
+				},
+				Spec: devportalv1alpha1.APIKeyApprovalSpec{
+					APIKeyRequestRef: devportalv1alpha1.APIKeyRequestReference{
+						Name: apiKeyRequest.Name,
+					},
+					Approved:   true,
+					ReviewedBy: "admin@example.com",
+					ReviewedAt: metav1.Now(),
+					Reason:     "ManuallyApproved",
+					Message:    "Manually approved by admin",
+				},
+			}
+			Expect(k8sClient.Create(ctx, manualApproval)).To(Succeed())
+		})
+
+		It("should not create automatic approval when manual approval exists", func() {
+			controllerReconciler := &APIKeyAutoApprovalReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requestKey := types.NamespacedName{
+				Name:      apiKeyRequest.Name,
+				Namespace: apiProductNamespace,
+			}
+
+			By("Waiting for APIKeyRequest status to be set")
+			Eventually(func() bool {
+				fetchedRequest := &devportalv1alpha1.APIKeyRequest{}
+				if err := k8sClient.Get(ctx, requestKey, fetchedRequest); err != nil {
+					return false
+				}
+				pendingCondition := meta.FindStatusCondition(fetchedRequest.Status.Conditions, devportalv1alpha1.APIKeyConditionPending)
+				return pendingCondition != nil && pendingCondition.Status == metav1.ConditionTrue
+			}, time.Second*5, time.Millisecond*250).Should(BeTrue(), "APIKeyRequest should have Pending condition set")
+
+			By("Running reconciliation")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: requestKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying only the manual approval exists (no automatic approval created)")
+			approvalList := &devportalv1alpha1.APIKeyApprovalList{}
+			Expect(k8sClient.List(ctx, approvalList, client.InNamespace(apiProductNamespace))).To(Succeed())
+			Expect(approvalList.Items).To(HaveLen(1), "Should have exactly one approval")
+			Expect(approvalList.Items[0].Name).To(Equal(manualApproval.Name), "Should be the manual approval")
+			Expect(approvalList.Items[0].Spec.ReviewedBy).To(Equal("admin@example.com"), "Should be manually approved")
 		})
 	})
 })

--- a/test/e2e/automatic_approval_test.go
+++ b/test/e2e/automatic_approval_test.go
@@ -29,12 +29,75 @@ import (
 
 var _ = Describe("Automatic Approval", Ordered, func() {
 	const (
-		ownerNamespace    = "api-owner-test"
-		consumerNamespace = "api-consumer-test"
-		kuadrantNamespace = "kuadrant-ns"
-		apiProductName    = "auto-approve-api"
-		apiKeyName        = "test-auto-apikey"
+		ownerNamespace      = "api-owner-test"
+		consumerNamespace   = "api-consumer-test"
+		kuadrantNamespace   = "kuadrant-ns"
+		apiProductName      = "auto-approve-api"
+		apiKeyName          = "test-auto-apikey"
+		controllerNamespace = "developer-portal-controller-system"
 	)
+
+	AfterEach(func() {
+		specReport := CurrentSpecReport()
+		if specReport.Failed() {
+			By("Fetching controller manager pod name")
+			cmd := exec.Command("kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", controllerNamespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get controller pod name: %s\n", err)
+				return
+			}
+			podNames := utils.GetNonEmptyLines(podOutput)
+			if len(podNames) == 0 {
+				_, _ = fmt.Fprintf(GinkgoWriter, "No controller pod found\n")
+				return
+			}
+			controllerPodName := podNames[0]
+
+			By("Fetching controller manager pod logs")
+			cmd = exec.Command("kubectl", "logs", controllerPodName, "-n", controllerNamespace)
+			controllerLogs, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", controllerLogs)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s\n", err)
+			}
+
+			By("Fetching Kubernetes events in owner namespace")
+			cmd = exec.Command("kubectl", "get", "events", "-n", ownerNamespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events in %s:\n%s\n", ownerNamespace, eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get events in %s: %s\n", ownerNamespace, err)
+			}
+
+			By("Fetching Kubernetes events in consumer namespace")
+			cmd = exec.Command("kubectl", "get", "events", "-n", consumerNamespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err = utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events in %s:\n%s\n", consumerNamespace, eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get events in %s: %s\n", consumerNamespace, err)
+			}
+
+			By("Fetching controller manager pod description")
+			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", controllerNamespace)
+			podDescription, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Pod description:\n%s\n", podDescription)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to describe controller pod: %s\n", err)
+			}
+		}
+	})
 
 	BeforeAll(func() {
 		By("creating the owner namespace")

--- a/test/e2e/automatic_approval_test.go
+++ b/test/e2e/automatic_approval_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kuadrant/developer-portal-controller/test/utils"
+)
+
+var _ = Describe("Automatic Approval", Ordered, func() {
+	const (
+		ownerNamespace    = "api-owner-test"
+		consumerNamespace = "api-consumer-test"
+		kuadrantNamespace = "kuadrant-ns"
+		apiProductName    = "auto-approve-api"
+		apiKeyName        = "test-auto-apikey"
+	)
+
+	BeforeAll(func() {
+		By("creating the owner namespace")
+		cmd := exec.Command("kubectl", "create", "ns", ownerNamespace)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create owner namespace")
+
+		By("creating the consumer namespace")
+		cmd = exec.Command("kubectl", "create", "ns", consumerNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create consumer namespace")
+
+		By("creating the kuadrant namespace")
+		cmd = exec.Command("kubectl", "create", "ns", kuadrantNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create kuadrant namespace")
+
+		By("creating the kuadrant instance")
+		kuadrantYAML := fmt.Sprintf(`
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: %s
+spec: {}
+`, kuadrantNamespace)
+
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = utils.StringReader(kuadrantYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kuadrant")
+	})
+
+	AfterAll(func() {
+		By("cleaning up kuadrant namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", kuadrantNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up owner namespace")
+		cmd = exec.Command("kubectl", "delete", "ns", ownerNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up consumer namespace")
+		cmd = exec.Command("kubectl", "delete", "ns", consumerNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+	})
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	Context("APIKey with automatic approval mode", func() {
+		It("should create APIKeyRequest, automatic approval, and approve the APIKey", func() {
+			By("creating an HTTPRoute as a reference target")
+			httpRouteYAML := fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route
+  namespace: %s
+spec:
+  parentRefs:
+  - name: test-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api
+    backendRefs:
+    - name: test-service
+      port: 8080
+`, ownerNamespace)
+
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(httpRouteYAML)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HTTPRoute")
+
+			By("creating an AuthPolicy with API key authentication")
+			authPolicyYAML := fmt.Sprintf(`
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: test-auth-policy
+  namespace: %s
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test-route
+  rules:
+    authentication:
+      "api-key":
+        apiKey:
+          selector:
+            matchLabels:
+              kuadrant.io/apikeys: "true"
+        credentials:
+          authorizationHeader:
+            prefix: "API-KEY"
+`, ownerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(authPolicyYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create AuthPolicy")
+
+			By("updating AuthPolicy status to Accepted and Enforced")
+			authPolicyStatusPatch := `{
+				"status": {
+					"conditions": [
+						{
+							"type": "Accepted",
+							"status": "True",
+							"reason": "Accepted",
+							"message": "AuthPolicy has been accepted",
+							"lastTransitionTime": "2024-01-01T00:00:00Z"
+						},
+						{
+							"type": "Enforced",
+							"status": "True",
+							"reason": "Enforced",
+							"message": "AuthPolicy has been successfully enforced",
+							"lastTransitionTime": "2024-01-01T00:00:00Z"
+						}
+					]
+				}
+			}`
+
+			cmd = exec.Command("kubectl", "patch", "authpolicy", "test-auth-policy",
+				"-n", ownerNamespace,
+				"--type=merge",
+				"--subresource=status",
+				"-p", authPolicyStatusPatch)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to update AuthPolicy status")
+
+			By("creating an APIProduct with automatic approval mode")
+			apiProductYAML := fmt.Sprintf(`
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  displayName: "Auto Approval Test API"
+  description: "API Product for testing automatic approval"
+  approvalMode: automatic
+  publishStatus: Published
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test-route
+`, apiProductName, ownerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(apiProductYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create APIProduct")
+
+			By("verifying APIProduct was created")
+			verifyAPIProductCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apiproduct", apiProductName,
+					"-n", ownerNamespace, "-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(apiProductName))
+			}
+			Eventually(verifyAPIProductCreated).Should(Succeed())
+
+			By("creating a secret with API key in the consumer namespace")
+			secretYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %s-secret
+  namespace: %s
+type: Opaque
+stringData:
+  api_key: test-api-key-value-12345
+`, apiKeyName, consumerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(secretYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create secret")
+
+			By("creating an APIKey in the consumer namespace")
+			apiKeyYAML := fmt.Sprintf(`
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIKey
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  apiProductRef:
+    name: %s
+    namespace: %s
+  secretRef:
+    name: %s-secret
+  planTier: premium
+  useCase: "Testing automatic approval flow"
+  requestedBy:
+    userId: test-user-123
+    email: test@example.com
+`, apiKeyName, consumerNamespace, apiProductName, ownerNamespace, apiKeyName)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(apiKeyYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create APIKey")
+
+			By("verifying APIKey was created")
+			verifyAPIKeyCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikey", apiKeyName,
+					"-n", consumerNamespace, "-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(apiKeyName))
+			}
+			Eventually(verifyAPIKeyCreated).Should(Succeed())
+
+			By("verifying APIKeyRequest was created in the owner namespace")
+			apiKeyRequestName := fmt.Sprintf("%s-%s", consumerNamespace, apiKeyName)
+			verifyAPIKeyRequestCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyrequest", apiKeyRequestName,
+					"-n", ownerNamespace, "-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(apiKeyRequestName))
+			}
+			Eventually(verifyAPIKeyRequestCreated).Should(Succeed())
+
+			By("verifying APIKeyApproval was automatically created")
+			verifyApprovalCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval",
+					"-n", ownerNamespace, "-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "APIKeyApproval should be created")
+				g.Expect(output).To(ContainSubstring("auto"), "APIKeyApproval name should contain 'auto'")
+			}
+			Eventually(verifyApprovalCreated).Should(Succeed())
+
+			By("verifying the approval was created by 'system'")
+			verifySystemReviewer := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval",
+					"-n", ownerNamespace, "-o", "jsonpath={.items[0].spec.reviewedBy}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("system"), "APIKeyApproval should be reviewed by 'system'")
+			}
+			Eventually(verifySystemReviewer).Should(Succeed())
+
+			By("verifying the approval is approved")
+			verifyApproved := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval",
+					"-n", ownerNamespace, "-o", "jsonpath={.items[0].spec.approved}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"), "APIKeyApproval should be approved")
+			}
+			Eventually(verifyApproved).Should(Succeed())
+
+			By("verifying the approval reason is AutoApproved")
+			verifyReason := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval",
+					"-n", ownerNamespace, "-o", "jsonpath={.items[0].spec.reason}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("AutoApproved"), "APIKeyApproval reason should be AutoApproved")
+			}
+			Eventually(verifyReason).Should(Succeed())
+
+			By("verifying APIKeyRequest gets Approved condition")
+			verifyRequestApproved := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyrequest", apiKeyRequestName,
+					"-n", ownerNamespace, "-o", "jsonpath={.status.conditions[?(@.type=='Approved')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"), "APIKeyRequest should have Approved=True condition")
+			}
+			Eventually(verifyRequestApproved).Should(Succeed())
+
+			By("verifying APIKey eventually gets Approved condition")
+			verifyAPIKeyApproved := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikey", apiKeyName,
+					"-n", consumerNamespace, "-o", "jsonpath={.status.conditions[?(@.type=='Approved')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"), "APIKey should have Approved=True condition")
+			}
+			Eventually(verifyAPIKeyApproved).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -78,9 +78,50 @@ var _ = BeforeSuite(func() {
 			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: CertManager is already installed. Skipping installation...\n")
 		}
 	}
+
+	// Before running the tests, set up the environment by creating the namespace,
+	// enforce the restricted security policy to the namespace, installing CRDs,
+	// and deploying the controller.
+
+	By("creating manager namespace")
+	cmd = exec.Command("kubectl", "create", "ns", namespace)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+	By("labeling the namespace to enforce the restricted security policy")
+	cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+		"pod-security.kubernetes.io/enforce=restricted")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+
+	By("installing CRDs")
+	cmd = exec.Command("make", "install")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+	By("deploying the controller-manager")
+	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
 })
 
 var _ = AfterSuite(func() {
+	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
+	// and deleting the namespace.
+
+	By("undeploying the controller-manager")
+	cmd := exec.Command("make", "undeploy")
+	_, _ = utils.Run(cmd)
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("make", "uninstall")
+	_, _ = utils.Run(cmd)
+
+	By("removing manager namespace")
+	cmd = exec.Command("kubectl", "delete", "ns", namespace)
+	_, _ = utils.Run(cmd)
+
 	// Teardown CertManager after the suite if not skipped and if it was not already installed
 	if !skipCertManagerInstall && !isCertManagerAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,55 +39,12 @@ const serviceAccountName = "developer-portal-controller-controller-manager"
 // metricsServiceName is the name of the metrics service of the project
 const metricsServiceName = "developer-portal-controller-controller-manager-metrics-service"
 
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "developer-portal-controller-metrics-binding"
-
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
-	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-	})
-
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
 	AfterAll(func() {
 		By("cleaning up the curl pod for metrics")
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
 		_, _ = utils.Run(cmd)
 	})
 
@@ -171,17 +128,9 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
-			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=developer-portal-controller-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
-
 			By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
+			cmd := exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
 
 			By("getting the service account token")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,17 +136,12 @@ var _ = Describe("Manager", Ordered, func() {
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "get", "clusterrolebinding", metricsRoleBindingName)
+			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+				"--clusterrole=developer-portal-controller-metrics-reader",
+				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
+			)
 			_, err := utils.Run(cmd)
-			if err != nil {
-				// ClusterRoleBinding doesn't exist, create it
-				cmd = exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-					"--clusterrole=developer-portal-controller-metrics-reader",
-					fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-				)
-				_, err = utils.Run(cmd)
-				Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
-			}
+			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
 
 			By("validating that the metrics service is available")
 			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,12 +39,19 @@ const serviceAccountName = "developer-portal-controller-controller-manager"
 // metricsServiceName is the name of the metrics service of the project
 const metricsServiceName = "developer-portal-controller-controller-manager-metrics-service"
 
+// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
+const metricsRoleBindingName = "developer-portal-controller-metrics-binding"
+
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
 	AfterAll(func() {
 		By("cleaning up the curl pod for metrics")
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up the ClusterRoleBinding for metrics")
+		cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName)
 		_, _ = utils.Run(cmd)
 	})
 
@@ -128,9 +135,22 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
-			By("validating that the metrics service is available")
-			cmd := exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
+			cmd := exec.Command("kubectl", "get", "clusterrolebinding", metricsRoleBindingName)
 			_, err := utils.Run(cmd)
+			if err != nil {
+				// ClusterRoleBinding doesn't exist, create it
+				cmd = exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+					"--clusterrole=developer-portal-controller-metrics-reader",
+					fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
+				)
+				_, err = utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+			}
+
+			By("validating that the metrics service is available")
+			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
 
 			By("getting the service account token")

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -251,4 +252,9 @@ func UncommentCode(filename, target, prefix string) error {
 	}
 
 	return nil
+}
+
+// StringReader converts a string to an io.Reader for use as stdin
+func StringReader(s string) io.Reader {
+	return strings.NewReader(s)
 }


### PR DESCRIPTION
# What

Adds automatic API key approval functionality that creates approvals when an APIProduct is configured with automatic approval mode.

# Verification Steps

APIKey Automatic Approval Workflow - Validation

This guide walks through the automatic approval workflow, where API keys are approved automatically without owner intervention when the APIProduct has `approvalMode: automatic`, and validates that owners can still manually deny auto-approved keys.

## Prerequisites

- Local environment set up with `make local-setup`

## Validation Steps

### 1. Owner: Enable Automatic Approval on APIProduct

Modify the gamestore-api APIProduct to enable automatic approval:

```bash
kubectl patch apiproduct gamestore-api -n gamestore --type=merge -p '{"spec":{"approvalMode":"automatic"}}'
```

**Verify the change:**

```bash
kubectl get apiproduct gamestore-api -n gamestore -o jsonpath='{.spec.approvalMode}'
```

**Expected output:** `automatic`

---

### 2. Consumer: Create Namespace

As an API consumer, create a namespace for your application:

```bash
kubectl create namespace consumer-app
```

---

### 3. Consumer: Create API Key Secret

Create a secret containing your API key value:

```bash
kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: gamestore-apikey-secret
  namespace: consumer-app
type: Opaque
stringData:
  api_key: my-secure-api-key-12345
EOF
```

---

### 4. Consumer: Create APIKey Request

Create an APIKey resource requesting access to the gamestore-api:

```bash
kubectl apply -f - <<EOF
apiVersion: devportal.kuadrant.io/v1alpha1
kind: APIKey
metadata:
  name: gamestore-apikey
  namespace: consumer-app
spec:
  apiProductRef:
    name: gamestore-api
    namespace: gamestore
  secretRef:
    name: gamestore-apikey-secret
  planTier: gold
  useCase: "Integration with our mobile gaming platform"
  requestedBy:
    userId: user-12345
    email: developer@consumer-app.com
EOF
```

---

### 5. Owner: Check APIKeyRequest Exists and is Pending

As an API owner, check that the APIKeyRequest shadow resource was created in your namespace:

```bash
kubectl get apikeyrequest -n gamestore
```

**Expected output:**

```
NAME                              AGE
consumer-app-gamestore-apikey     <time>
```

---

### 6. Owner: Verify APIKeyApproval Was Automatically Created

Check that the controller automatically created an APIKeyApproval resource:

```bash
kubectl get apikeyapproval -n gamestore
```

**Expected output:**

```
NAME                        AGE
consumer-app-gamestore-apikey-auto   <time>
```

**Inspect the automatic approval:**

```bash
kubectl get apikeyapproval consumer-app-gamestore-apikey-auto -n gamestore -o yaml
```

**Expected details:**

- `spec.approved: true`
- `spec.reviewedBy: "system"` (not a human reviewer - this is the key difference from manual approval)
- `spec.reason: "AutoApproved"`
- `spec.message: "APIProduct is configured for automatic approval"`
- `spec.apiKeyRequestRef` pointing to the APIKeyRequest

---

### 7. Consumer: Check APIKey Status (Approved)

Back as the consumer, check that the APIKey has been automatically approved:

```bash
kubectl get apikey gamestore-apikey -n consumer-app -o jsonpath='{.status}' | yq e -P
```

The APIKey should show an `Approved` condition:

**Expected output should include:**

```yaml
status:
  conditions:
  - type: Approved
    status: "True"
    reason: AutoApproved
    message: "API key request automatically approved by system: APIProduct is configured for automatic approval"
    lastTransitionTime: "<timestamp>"
```

**Key difference from manual approval:** The message shows "automatically approved by system" instead of a human reviewer.

**Quick check:**

```bash
kubectl get apikey gamestore-apikey -n consumer-app -o jsonpath='{.status.conditions[?(@.type=="Approved")].status}'
```

**Expected output:** `True`

---

## Denial Workflow (Owner Manually Denies Auto-Approved Key)

Even though the APIKey was automatically approved, the owner can still manually deny it by patching the approval.

### 8. Owner: Deny the Auto-Approved Request

The owner decides to revoke access by patching the automatically-created APIKeyApproval:

```bash
# Get the auto-approval name
APPROVAL_NAME=$(kubectl get apikeyapproval -n gamestore -o jsonpath='{.items[0].metadata.name}')

# Patch the approval to denied
kubectl patch apikeyapproval $APPROVAL_NAME -n gamestore --type=merge --patch='{"spec":{"approved":false,"reason":"Denied","message":"Use case no longer meets security requirements"}}'
```

**Verify:**

```bash
kubectl get apikeyapproval $APPROVAL_NAME -n gamestore -o jsonpath='{.spec.approved}'
```

**Expected output:** `false`

**Verify the denial details:**

```bash
kubectl get apikeyapproval $APPROVAL_NAME -n gamestore -o jsonpath='{.spec}' | yq e -P
```

**Expected:**

```yaml
approved: false
reason: Denied
message: "Use case no longer meets security requirements"
reviewedBy: system  # Still shows "system" since it was auto-created
# ...
```

---

### 9. Consumer: Check APIKey Status (Denied)

Back as the consumer, verify the APIKey status has changed to Denied:

```bash
kubectl get apikey gamestore-apikey -n consumer-app -o jsonpath='{.status}' | yq e -P
```

**Expected output should include:**

```yaml
status:
  conditions:
  - type: Denied
    status: "True"
    reason: Denied
    message: "API key request denied by system: Use case no longer meets security requirements"
    lastTransitionTime: "<timestamp>"
  observedGeneration: 1
```

---

### 10. Verify Enforcement Secret is Removed

Check that the controller has removed the enforcement secret, making the API key no longer effective:

```bash
# Try to find the secret using labels
kubectl get secrets -n kuadrant-system \
  -l "devportal.kuadrant.io/apikey=gamestore-apikey,devportal.kuadrant.io/apikey-namespace=consumer-app"
```

**Expected output:**

```
No resources found in kuadrant-system namespace.
```

**Alternative check - list all devportal enforcement secrets:**

```bash
kubectl get secrets -n kuadrant-system -l "devportal.kuadrant.io/apikey"
```

**Expected:** No resources found (or the specific secret for gamestore-apikey is gone)

---

## Cleanup

```bash
make kind-delete-cluster
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic API key approval functionality that creates approvals when an API product is configured with automatic approval mode.

* **Tests**
  * Enhanced E2E test infrastructure with improved setup and teardown processes.
  * Added comprehensive E2E test coverage for automatic API key approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
