### PR TITLE
useCase field optional in the APIKey type

### DIFF
--- a/api/v1alpha1/apikey_types.go
+++ b/api/v1alpha1/apikey_types.go
@@ -64,8 +64,8 @@ type APIKeySpec struct {
 	PlanTier string `json:"planTier"`
 
 	// UseCase describes how the API key will be used
-	// +kubebuilder:validation:Required
-	UseCase string `json:"useCase"`
+	// +optional
+	UseCase string `json:"useCase,omitempty"`
 
 	// RequestedBy contains information about who requested the API key
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
+++ b/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
@@ -113,7 +113,6 @@ spec:
             - planTier
             - requestedBy
             - secretRef
-            - useCase
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.

--- a/docs/references/apikey.md
+++ b/docs/references/apikey.md
@@ -18,7 +18,7 @@ The APIKey CRD is part of the Developer Portal extension for Kuadrant. It repres
 | `apiProductRef` | [APIProductReference](#apiproductreference) | Yes       | Reference to the APIProduct this API key provides access to             |
 | `secretRef`     | [LocalObjectReference](#localobjectreference) | Yes      | Reference to the secret containing the API key in the consumer's namespace |
 | `planTier`      | String                                    | Yes          | Tier of the plan (e.g., "premium", "basic", "enterprise")                |
-| `useCase`       | String                                    | Yes          | Description of how the API key will be used                              |
+| `useCase`       | String                                    | No           | Description of how the API key will be used                              |
 | `requestedBy`   | [RequestedBy](#requestedby)               | Yes          | Information about who requested the API key                              |
 
 ### APIProductReference


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `useCase` field in API Key specifications is now optional rather than required, allowing API Keys to be created without specifying a use case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/developer-portal-controller/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->