### PR TITLE
chore: update ci job names

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: Run E2E tests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Run unittests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION
## Summary

Update CI workflow job names to be more descriptive and meaningful.

## Changes

Renamed GitHub Actions workflow job names from generic "Run on Ubuntu" to descriptive names:
- **Lint workflow**: `Run on Ubuntu` → `Lint`
- **E2E test workflow**: `Run on Ubuntu` → `Run E2E tests`
- **Unit test workflow**: `Run on Ubuntu` → `Run unittests`

## Motivation

The previous generic job names made it difficult to identify which CI checks failed at a glance in PR status checks. Using descriptive names improves developer experience by making it immediately clear which test suite or check is passing/failing.

## Impact

These renamed jobs will be configured as required status checks for PR merging, ensuring that:
- All code passes linting (golangci-lint)
- Unit tests pass
- E2E tests pass

This enforces code quality and test coverage standards before merging to main.