### PR TITLE
Add missing delete permission for APIKeyApproval owner references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,8 +18,11 @@ rules:
   - devportal.kuadrant.io
   resources:
   - apikeyapprovals
+  - apikeyrequests
+  - apiproducts
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -36,19 +39,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - devportal.kuadrant.io
-  resources:
-  - apikeyrequests
-  - apiproducts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - devportal.kuadrant.io
   resources:

--- a/internal/controller/apikeyapproval_controller.go
+++ b/internal/controller/apikeyapproval_controller.go
@@ -38,7 +38,7 @@ type APIKeyApprovalReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyapprovals,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyapprovals,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyrequests,verbs=get;list;watch
 
 // Reconcile handles reconciling all APIKeyApprovals in a single call. Any resource event should enqueue the

--- a/test/e2e/apikey_approval_gc_test.go
+++ b/test/e2e/apikey_approval_gc_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kuadrant/developer-portal-controller/test/utils"
+)
+
+var _ = Describe("APIKeyApproval Garbage Collection", Ordered, func() {
+	const (
+		ownerNamespace      = "gc-owner-test"
+		consumerNamespace   = "gc-consumer-test"
+		kuadrantNamespace   = "gc-kuadrant-ns"
+		controllerNamespace = "developer-portal-controller-system"
+	)
+
+	AfterEach(func() {
+		specReport := CurrentSpecReport()
+		if specReport.Failed() {
+			By("Fetching controller manager pod name")
+			cmd := exec.Command("kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", controllerNamespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get controller pod name: %s\n", err)
+				return
+			}
+			podNames := utils.GetNonEmptyLines(podOutput)
+			if len(podNames) == 0 {
+				_, _ = fmt.Fprintf(GinkgoWriter, "No controller pod found\n")
+				return
+			}
+			controllerPodName := podNames[0]
+
+			By("Fetching controller manager pod logs")
+			cmd = exec.Command("kubectl", "logs", controllerPodName, "-n", controllerNamespace)
+			controllerLogs, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", controllerLogs)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s\n", err)
+			}
+
+			By("Fetching Kubernetes events in owner namespace")
+			cmd = exec.Command("kubectl", "get", "events", "-n", ownerNamespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events in %s:\n%s\n", ownerNamespace, eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get events in %s: %s\n", ownerNamespace, err)
+			}
+
+			By("Fetching Kubernetes events in consumer namespace")
+			cmd = exec.Command("kubectl", "get", "events", "-n", consumerNamespace, "--sort-by=.lastTimestamp")
+			eventsOutput, err = utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events in %s:\n%s\n", consumerNamespace, eventsOutput)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get events in %s: %s\n", consumerNamespace, err)
+			}
+		}
+	})
+
+	BeforeAll(func() {
+		By("creating the owner namespace")
+		cmd := exec.Command("kubectl", "create", "ns", ownerNamespace)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create owner namespace")
+
+		By("creating the consumer namespace")
+		cmd = exec.Command("kubectl", "create", "ns", consumerNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create consumer namespace")
+
+		By("creating the kuadrant namespace")
+		cmd = exec.Command("kubectl", "create", "ns", kuadrantNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create kuadrant namespace")
+
+		By("creating the kuadrant instance")
+		kuadrantYAML := fmt.Sprintf(`
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: %s
+spec: {}
+`, kuadrantNamespace)
+
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = utils.StringReader(kuadrantYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kuadrant")
+	})
+
+	AfterAll(func() {
+		By("cleaning up kuadrant namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", kuadrantNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up owner namespace")
+		cmd = exec.Command("kubectl", "delete", "ns", ownerNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up consumer namespace")
+		cmd = exec.Command("kubectl", "delete", "ns", consumerNamespace, "--wait=false")
+		_, _ = utils.Run(cmd)
+	})
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	Context("APIKeyApproval owner reference and garbage collection", func() {
+		It("should garbage collect APIKeyApproval when APIKey is deleted", func() {
+			By("creating an HTTPRoute as a reference target")
+			httpRouteYAML := fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route-gc
+  namespace: %s
+spec:
+  parentRefs:
+  - name: test-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api
+    backendRefs:
+    - name: test-service
+      port: 8080
+`, ownerNamespace)
+
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(httpRouteYAML)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create HTTPRoute")
+
+			By("creating an AuthPolicy with API key authentication")
+			authPolicyYAML := fmt.Sprintf(`
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: test-auth-policy-gc
+  namespace: %s
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test-route-gc
+  rules:
+    authentication:
+      "api-key":
+        apiKey:
+          selector:
+            matchLabels:
+              kuadrant.io/apikeys: "true"
+        credentials:
+          authorizationHeader:
+            prefix: "API-KEY"
+`, ownerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(authPolicyYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create AuthPolicy")
+
+			By("updating AuthPolicy status to Accepted and Enforced")
+			authPolicyStatusPatch := `{
+				"status": {
+					"conditions": [
+						{
+							"type": "Accepted",
+							"status": "True",
+							"reason": "Accepted",
+							"message": "AuthPolicy has been accepted",
+							"lastTransitionTime": "2024-01-01T00:00:00Z"
+						},
+						{
+							"type": "Enforced",
+							"status": "True",
+							"reason": "Enforced",
+							"message": "AuthPolicy has been successfully enforced",
+							"lastTransitionTime": "2024-01-01T00:00:00Z"
+						}
+					]
+				}
+			}`
+
+			cmd = exec.Command("kubectl", "patch", "authpolicy", "test-auth-policy-gc",
+				"-n", ownerNamespace,
+				"--type=merge",
+				"--subresource=status",
+				"-p", authPolicyStatusPatch)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to update AuthPolicy status")
+
+			By("creating an APIProduct with automatic approval mode")
+			apiProductGCName := "gc-test-api"
+			apiProductYAML := fmt.Sprintf(`
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  displayName: "Garbage Collection Test API"
+  description: "API Product for testing garbage collection"
+  approvalMode: automatic
+  publishStatus: Published
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test-route-gc
+`, apiProductGCName, ownerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(apiProductYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create APIProduct")
+
+			By("creating a secret with API key in the consumer namespace")
+			apiKeyGCName := "gc-test-apikey"
+			secretYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %s-secret
+  namespace: %s
+type: Opaque
+stringData:
+  api_key: gc-test-key-value-12345
+`, apiKeyGCName, consumerNamespace)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(secretYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create secret")
+
+			By("creating an APIKey in the consumer namespace")
+			apiKeyYAML := fmt.Sprintf(`
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIKey
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  apiProductRef:
+    name: %s
+    namespace: %s
+  secretRef:
+    name: %s-secret
+  planTier: premium
+  useCase: "Testing garbage collection"
+  requestedBy:
+    userId: gc-test-user-123
+    email: gctest@example.com
+`, apiKeyGCName, consumerNamespace, apiProductGCName, ownerNamespace, apiKeyGCName)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = utils.StringReader(apiKeyYAML)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create APIKey")
+
+			By("verifying APIKeyRequest was created in the owner namespace")
+			var apiKeyRequestName string
+			verifyAPIKeyRequestCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyrequest",
+					"-n", ownerNamespace,
+					"-o", "jsonpath={.items[?(@.spec.apiKeyRef.name=='"+apiKeyGCName+"')].metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "APIKeyRequest should be created")
+				apiKeyRequestName = output
+			}
+			Eventually(verifyAPIKeyRequestCreated).Should(Succeed())
+
+			By("verifying APIKeyApproval was automatically created")
+			apiKeyApprovalName := fmt.Sprintf("%s-auto", apiKeyRequestName)
+			verifyApprovalCreated := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval", apiKeyApprovalName,
+					"-n", ownerNamespace, "-o", "jsonpath={.metadata.name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(apiKeyApprovalName), "APIKeyApproval should be created")
+			}
+			Eventually(verifyApprovalCreated).Should(Succeed())
+
+			By("verifying APIKeyApproval has owner reference to APIKeyRequest")
+			verifyOwnerReference := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval", apiKeyApprovalName,
+					"-n", ownerNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].name}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal(apiKeyRequestName), "APIKeyApproval should have owner reference to APIKeyRequest")
+			}
+			Eventually(verifyOwnerReference).Should(Succeed())
+
+			By("verifying owner reference kind is APIKeyRequest")
+			verifyOwnerKind := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval", apiKeyApprovalName,
+					"-n", ownerNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].kind}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("APIKeyRequest"), "Owner reference kind should be APIKeyRequest")
+			}
+			Eventually(verifyOwnerKind).Should(Succeed())
+
+			By("verifying owner reference controller is set to true")
+			verifyOwnerController := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval", apiKeyApprovalName,
+					"-n", ownerNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].controller}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"), "Owner reference controller should be true")
+			}
+			Eventually(verifyOwnerController).Should(Succeed())
+
+			By("deleting the APIKey")
+			cmd = exec.Command("kubectl", "delete", "apikey", apiKeyGCName, "-n", consumerNamespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete APIKey")
+
+			By("verifying APIKeyRequest is deleted")
+			verifyAPIKeyRequestDeleted := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyrequest", apiKeyRequestName,
+					"-n", ownerNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "APIKeyRequest should be deleted")
+			}
+			Eventually(verifyAPIKeyRequestDeleted, 30*time.Second).Should(Succeed())
+
+			By("verifying APIKeyApproval is garbage collected")
+			verifyApprovalDeleted := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "apikeyapproval", apiKeyApprovalName,
+					"-n", ownerNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "APIKeyApproval should be garbage collected")
+			}
+			Eventually(verifyApprovalDeleted, 30*time.Second).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/apikey_approval_gc_test.go
+++ b/test/e2e/apikey_approval_gc_test.go
@@ -89,35 +89,11 @@ var _ = Describe("APIKeyApproval Garbage Collection", Ordered, func() {
 	})
 
 	BeforeAll(func() {
-		By("creating the owner namespace")
-		cmd := exec.Command("kubectl", "create", "ns", ownerNamespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create owner namespace")
+		SetDefaultEventuallyTimeout(2 * time.Minute)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
-		By("creating the consumer namespace")
-		cmd = exec.Command("kubectl", "create", "ns", consumerNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create consumer namespace")
-
-		By("creating the kuadrant namespace")
-		cmd = exec.Command("kubectl", "create", "ns", kuadrantNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create kuadrant namespace")
-
-		By("creating the kuadrant instance")
-		kuadrantYAML := fmt.Sprintf(`
-apiVersion: kuadrant.io/v1beta1
-kind: Kuadrant
-metadata:
-  name: kuadrant
-  namespace: %s
-spec: {}
-`, kuadrantNamespace)
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = utils.StringReader(kuadrantYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create Kuadrant")
+		By("setting up namespaces and Kuadrant instance")
+		SetupNamespacesAndKuadrant(ownerNamespace, consumerNamespace, kuadrantNamespace)
 	})
 
 	AfterAll(func() {
@@ -133,9 +109,6 @@ spec: {}
 		cmd = exec.Command("kubectl", "delete", "ns", consumerNamespace, "--wait=false")
 		_, _ = utils.Run(cmd)
 	})
-
-	SetDefaultEventuallyTimeout(2 * time.Minute)
-	SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 	Context("APIKeyApproval owner reference and garbage collection", func() {
 		It("should garbage collect APIKeyApproval when APIKey is deleted", func() {

--- a/test/e2e/automatic_approval_test.go
+++ b/test/e2e/automatic_approval_test.go
@@ -100,35 +100,11 @@ var _ = Describe("Automatic Approval", Ordered, func() {
 	})
 
 	BeforeAll(func() {
-		By("creating the owner namespace")
-		cmd := exec.Command("kubectl", "create", "ns", ownerNamespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create owner namespace")
+		SetDefaultEventuallyTimeout(2 * time.Minute)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
-		By("creating the consumer namespace")
-		cmd = exec.Command("kubectl", "create", "ns", consumerNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create consumer namespace")
-
-		By("creating the kuadrant namespace")
-		cmd = exec.Command("kubectl", "create", "ns", kuadrantNamespace)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create kuadrant namespace")
-
-		By("creating the kuadrant instance")
-		kuadrantYAML := fmt.Sprintf(`
-apiVersion: kuadrant.io/v1beta1
-kind: Kuadrant
-metadata:
-  name: kuadrant
-  namespace: %s
-spec: {}
-`, kuadrantNamespace)
-
-		cmd = exec.Command("kubectl", "apply", "-f", "-")
-		cmd.Stdin = utils.StringReader(kuadrantYAML)
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create Kuadrant")
+		By("setting up namespaces and Kuadrant instance")
+		SetupNamespacesAndKuadrant(ownerNamespace, consumerNamespace, kuadrantNamespace)
 	})
 
 	AfterAll(func() {
@@ -144,9 +120,6 @@ spec: {}
 		cmd = exec.Command("kubectl", "delete", "ns", consumerNamespace, "--wait=false")
 		_, _ = utils.Run(cmd)
 	})
-
-	SetDefaultEventuallyTimeout(2 * time.Minute)
-	SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 	Context("APIKey with automatic approval mode", func() {
 		It("should create APIKeyRequest, automatic approval, and approve the APIKey", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -45,6 +45,11 @@ const metricsRoleBindingName = "developer-portal-controller-metrics-binding"
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
+	BeforeAll(func() {
+		SetDefaultEventuallyTimeout(2 * time.Minute)
+		SetDefaultEventuallyPollingInterval(time.Second)
+	})
+
 	AfterAll(func() {
 		By("cleaning up the curl pod for metrics")
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
@@ -97,9 +102,6 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 		}
 	})
-
-	SetDefaultEventuallyTimeout(2 * time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Context("Manager", func() {
 		It("should run successfully", func() {

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/onsi/gomega"
+
+	"github.com/kuadrant/developer-portal-controller/test/utils"
+)
+
+// SetupNamespacesAndKuadrant creates the owner, consumer, and kuadrant namespaces,
+// and creates a Kuadrant instance. This is a common setup step for e2e tests.
+func SetupNamespacesAndKuadrant(ownerNamespace, consumerNamespace, kuadrantNamespace string) {
+	cmd := exec.Command("kubectl", "create", "ns", ownerNamespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create owner namespace")
+
+	cmd = exec.Command("kubectl", "create", "ns", consumerNamespace)
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create consumer namespace")
+
+	cmd = exec.Command("kubectl", "create", "ns", kuadrantNamespace)
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create kuadrant namespace")
+
+	kuadrantYAML := fmt.Sprintf(`
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: %s
+spec: {}
+`, kuadrantNamespace)
+
+	cmd = exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = utils.StringReader(kuadrantYAML)
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Kuadrant")
+}


### PR DESCRIPTION
## Summary
- Add `delete` permission to APIKeyApprovalReconciler RBAC for setting owner references
- Add e2e test to verify APIKeyApproval garbage collection when APIKey is deleted

## Problem
The controller was failing to set owner references on APIKeyApproval resources with the error:
```
cannot set an ownerRef on a resource you can't delete
```

Kubernetes requires `delete` permission on a resource before you can set owner references that enable garbage collection.

## Solution
- Added `delete` verb to the `apikeyapprovals` RBAC marker in `apikeyapproval_controller.go`
- Regenerated RBAC manifests with `make manifests`
- Added e2e test (`apikey_approval_gc_test.go`) that validates:
  - APIKeyApproval gets owner reference to APIKeyRequest
  - APIKeyApproval is automatically garbage collected when APIKey is deleted

## Testing
The new e2e test verifies the complete cleanup chain:
1. Delete APIKey → APIKeyRequestReconciler deletes APIKeyRequest
2. Delete APIKeyRequest → Kubernetes GC deletes APIKeyApproval (via owner reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end test suite validating APIKeyApproval garbage collection behaviour, confirming that approval records are automatically cleaned up when their associated API keys are deleted from the system.

* **Chores**
  * Updated role-based access control permissions to enable APIKeyApproval deletion operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/developer-portal-controller/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->