### PR TITLE
Add finalizers permission for APIKeyRequest owner references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,12 @@ rules:
 - apiGroups:
   - devportal.kuadrant.io
   resources:
+  - apikeyrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
   - apikeys
   verbs:
   - get

--- a/internal/controller/apikeyapproval_controller.go
+++ b/internal/controller/apikeyapproval_controller.go
@@ -40,6 +40,7 @@ type APIKeyApprovalReconciler struct {
 
 // +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyapprovals,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyrequests,verbs=get;list;watch
+// +kubebuilder:rbac:groups=devportal.kuadrant.io,resources=apikeyrequests/finalizers,verbs=update
 
 // Reconcile handles reconciling all APIKeyApprovals in a single call. Any resource event should enqueue the
 // same reconcile.Request containing this controller name, i.e. "apikeyapproval". This allows multiple resource updates to

--- a/internal/controller/apikeyapproval_controller.go
+++ b/internal/controller/apikeyapproval_controller.go
@@ -125,7 +125,6 @@ func (r *APIKeyApprovalReconciler) reconcileOwnerReference(ctx context.Context, 
 
 	// Update the APIKeyApproval with the owner reference
 	if err := r.Update(ctx, approval); err != nil {
-		logger.Error(err, "Failed to update APIKeyApproval with owner reference")
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Added RBAC permission to update finalizers on `apikeyrequests` resource
- Fixes error: "cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on"

## Why

When `APIKeyApprovalReconciler` sets an owner reference from APIKeyRequest to APIKeyApproval using `controllerutil.SetControllerReference()`, it sets `blockOwnerDeletion: true` by default. Openshift requires the controller to have permission to update finalizers on the owner resource to prevent orphaned resources.

Without this permission, the controller fails with the error mentioned above.

## Test plan

- [ ] Deploy controller with updated RBAC permissions
- [ ] Create APIKey and APIKeyApproval resources
- [ ] Verify APIKeyApproval gets owner reference set without errors
- [ ] Check controller logs show no RBAC permission errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated role-based access control permissions for API key request management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/developer-portal-controller/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->