### PR TITLE
Upgrade Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GIT_SHA

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/developer-portal-controller
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

**Changes:**
- `go.mod`: updated Go version from 1.25.9 to 1.26.3
- `Dockerfile`: updated builder image from `golang:1.25` to `golang:1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Go 1.26 across the Docker build stage and project toolchain settings.
  * No changes were made to application features, dependencies, or runtime behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->