### PR TITLE
Release v0.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.0
+VERSION ?= 0.2.1
 
 # QUAY_IMAGE_EXPIRY defines when to expire the built quay images.
 # The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively,


### PR DESCRIPTION
Bump VERSION from 0.2.0 to 0.2.1.

Once merged, tag `v0.2.1` from the release branch. The image build triggers on tag push.

The automated release workflow failed because it tried to create a `release-0.2.1` branch which is blocked by repo rules. This follows the manual workflow instead.